### PR TITLE
Add support for a redis cache manager that connects to a sentinel-man…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 	  <!-- Note: this should be in-sync with the version in sharedmultijar_release/pom.xml that is used for student and proctor -->
 		<org.springframework-version>3.2.1.RELEASE</org.springframework-version>
 		<org.springframework-webflow-version>2.3.2.RELEASE</org.springframework-webflow-version>
+	  	<spring-data-redis.version>1.2.1.RELEASE</spring-data-redis.version>
+	    <jedis.version>2.4.1</jedis.version>
 		<org.aspectj-version>1.6.10</org.aspectj-version>
 		<org.slf4j-version>1.7.5</org.slf4j-version>
 		<org.log4j-version>1.2.17</org.log4j-version>
@@ -41,7 +43,9 @@
 		<javax.el-version>3.0-b07</javax.el-version>
 		<jsp-api-version>2.1</jsp-api-version>
 		<jstl-version>1.2</jstl-version>
+	  	<assertj-version>2.5.0</assertj-version>
 		<junit-version>4.11</junit-version>
+	  	<mockito-version>1.10.19</mockito-version>
 		<maven-eclipse-plugin-version>2.9</maven-eclipse-plugin-version>
 	  	<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
 		<maven-jxr-plugin-version>2.3</maven-jxr-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
 	  <!-- Note: this should be in-sync with the version in sharedmultijar_release/pom.xml that is used for student and proctor -->
 		<org.springframework-version>3.2.1.RELEASE</org.springframework-version>
 		<org.springframework-webflow-version>2.3.2.RELEASE</org.springframework-webflow-version>
-	  	<spring-data-redis.version>1.2.1.RELEASE</spring-data-redis.version>
-	    <jedis.version>2.4.1</jedis.version>
+		<spring-data-redis.version>1.2.1.RELEASE</spring-data-redis.version>
+		<jedis.version>2.4.1</jedis.version>
 		<org.aspectj-version>1.6.10</org.aspectj-version>
 		<org.slf4j-version>1.7.5</org.slf4j-version>
 		<org.log4j-version>1.2.17</org.log4j-version>
@@ -43,9 +43,9 @@
 		<javax.el-version>3.0-b07</javax.el-version>
 		<jsp-api-version>2.1</jsp-api-version>
 		<jstl-version>1.2</jstl-version>
-	  	<assertj-version>2.5.0</assertj-version>
+		<assertj-version>2.5.0</assertj-version>
 		<junit-version>4.11</junit-version>
-	  	<mockito-version>1.10.19</mockito-version>
+		<mockito-version>1.10.19</mockito-version>
 		<maven-eclipse-plugin-version>2.9</maven-eclipse-plugin-version>
 	  	<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
 		<maven-jxr-plugin-version>2.3</maven-jxr-plugin-version>

--- a/tds-dll-common/pom.xml
+++ b/tds-dll-common/pom.xml
@@ -16,29 +16,6 @@
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.opentestsystem.shared</groupId>
-			<artifactId>shared-db</artifactId>
-		</dependency>
-    	<dependency>
-			<groupId>org.opentestsystem.shared</groupId>
-			<artifactId>shared-tr-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context-support</artifactId>
-			<version>${org.springframework-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<version>${org.springframework-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>15.0</version>
-		</dependency>
 		<!-- Start: Program management integration dependency -->
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
@@ -52,6 +29,68 @@
 			<version>${progman-client.version}</version>
 		</dependency>
 		<!-- End: Program management integration dependency -->
+
+		<dependency>
+			<groupId>org.opentestsystem.shared</groupId>
+			<artifactId>shared-db</artifactId>
+		</dependency>
+
+    	<dependency>
+			<groupId>org.opentestsystem.shared</groupId>
+			<artifactId>shared-tr-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-redis</artifactId>
+			<version>${spring-data-redis.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>15.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
+			<version>${jedis.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit-version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj-version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito-version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>

--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactory.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactory.java
@@ -1,0 +1,181 @@
+package tds.dll.common.performance.caching.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnection;
+import org.springframework.data.redis.connection.jedis.JedisConverters;
+import org.springframework.util.Assert;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.Protocol;
+import redis.clients.util.Pool;
+
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+/**
+ * This class is a copy of Spring's JedisConnectionFactory with support for a JedisSentinelPool.
+ */
+public class JedisSentinelConnectionFactory implements InitializingBean, DisposableBean, RedisConnectionFactory {
+
+    private final static Logger LOG = LoggerFactory.getLogger(JedisSentinelConnectionFactory.class);
+
+    private final String masterName;
+    private final Set<String> sentinels = newHashSet();
+
+    private JedisPoolConfig poolConfig = new JedisPoolConfig();
+    private int timeout = Protocol.DEFAULT_TIMEOUT;
+    private String password;
+    private int dbIndex = 0;
+    private boolean convertPipelineAndTxResults = true;
+    private Pool<Jedis> pool;
+
+    public JedisSentinelConnectionFactory(final String masterName,
+                                          final Set<String> sentinels) {
+        this.masterName = masterName;
+        this.sentinels.addAll(sentinels);
+    }
+
+    @Override
+    public JedisConnection getConnection() {
+        final Jedis jedis = fetchJedisConnector();
+        final JedisConnection connection = createConnection(jedis);
+        connection.setConvertPipelineAndTxResults(convertPipelineAndTxResults);
+        return postProcessConnection(connection);
+    }
+
+    @Override
+    public boolean getConvertPipelineAndTxResults() {
+        return convertPipelineAndTxResults;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        pool = createPool();
+    }
+
+    @Override
+    public void destroy() {
+        if (pool == null) return;
+
+        try {
+            pool.destroy();
+        } catch (final Exception ex) {
+            LOG.warn("Cannot properly close Jedis pool", ex);
+        }
+        pool = null;
+    }
+
+    @Override
+    public DataAccessException translateExceptionIfPossible(final RuntimeException ex) {
+        return JedisConverters.toDataAccessException(ex);
+    }
+
+    /**
+     * @return password for authentication
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @param password the password to set
+     */
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    /**
+     * @return Returns the timeout
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * @param timeout The timeout to set.
+     */
+    public void setTimeout(final int timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * @return Returns the poolConfig
+     */
+    public JedisPoolConfig getPoolConfig() {
+        return poolConfig;
+    }
+
+    /**
+     * @param poolConfig The poolConfig to set.
+     */
+    public void setPoolConfig(final JedisPoolConfig poolConfig) {
+        this.poolConfig = poolConfig;
+    }
+
+    /**
+     * @return Returns the database index
+     */
+    public int getDatabase() {
+        return dbIndex;
+    }
+
+    /**
+     * @param index database index
+     */
+    public void setDatabase(final int index) {
+        Assert.isTrue(index >= 0, "invalid DB index (a positive index required)");
+        this.dbIndex = index;
+    }
+
+    /**
+     * @param convertPipelineAndTxResults Whether or not to convert pipeline and tx results
+     */
+    public void setConvertPipelineAndTxResults(final boolean convertPipelineAndTxResults) {
+        this.convertPipelineAndTxResults = convertPipelineAndTxResults;
+    }
+
+    /**
+     * Returns a Jedis instance to be used as a Redis connection. The instance can be newly created or retrieved from a
+     * pool.
+     *
+     * @return Jedis instance ready for wrapping into a {@link RedisConnection}.
+     */
+    protected Jedis fetchJedisConnector() {
+        try {
+            return pool.getResource();
+        } catch (final Exception ex) {
+            throw new RedisConnectionFailureException("Cannot get Jedis connection", ex);
+        }
+    }
+
+    /**
+     * Post process a newly retrieved connection. Useful for decorating or executing initialization commands on a new
+     * connection. This implementation simply returns the connection.
+     *
+     * @param connection    The jedis connection
+     * @return processed connection
+     */
+    protected JedisConnection postProcessConnection(final JedisConnection connection) {
+        return connection;
+    }
+
+    @VisibleForTesting
+    Pool<Jedis> createPool() {
+        return new JedisSentinelPool(masterName, sentinels, poolConfig, timeout, password);
+    }
+
+    @VisibleForTesting
+    JedisConnection createConnection(final Jedis jedis) {
+        return new JedisConnection(jedis, pool, dbIndex);
+    }
+}

--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManager.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManager.java
@@ -1,0 +1,43 @@
+package tds.dll.common.performance.caching.impl;
+
+import com.google.common.collect.ImmutableList;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import tds.dll.common.performance.caching.CacheType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This implementation of a RedisCacheManager configures internal caches based upon the cache name.
+ */
+public class NameAwareRedisCacheManager extends RedisCacheManager {
+
+    public NameAwareRedisCacheManager(final RedisTemplate redisOperations,
+                                      final long shortTerm,
+                                      final long mediumTerm,
+                                      final long longTerm) {
+        super(redisOperations);
+        super.setExpires(asExpires(shortTerm, mediumTerm, longTerm));
+        super.setDefaultExpiration(longTerm);
+        super.setCacheNames(ImmutableList.of(CacheType.ShortTerm, CacheType.MediumTerm, CacheType.LongTerm));
+    }
+
+    /**
+     * Convert the configured short, medium, and long-term expirations into the expected expiration format.
+     *
+     * @param shortTerm     Short-term expiration in seconds
+     * @param mediumTerm    Medium-term expiration in seconds
+     * @param longTerm      Long-term expiration in seconds
+     * @return  A cache-name expiration map
+     */
+    Map<String, Long> asExpires(final long shortTerm,
+                                final long mediumTerm,
+                                final long longTerm) {
+        final Map<String, Long> expireMap = new HashMap<>();
+        expireMap.put(CacheType.ShortTerm, shortTerm);
+        expireMap.put(CacheType.MediumTerm, mediumTerm);
+        expireMap.put(CacheType.LongTerm, longTerm);
+        return expireMap;
+    }
+}

--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/RedisJsonSerializer.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/RedisJsonSerializer.java
@@ -1,0 +1,52 @@
+package tds.dll.common.performance.caching.impl;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+import java.io.IOException;
+
+/**
+ * This serializer is responsible for serializing/deserializing an object using the Jackson ObjectMapper.
+ */
+public class RedisJsonSerializer implements RedisSerializer<Object> {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Constructor
+     * NOTE: We clone and modify the application-wide ObjectMapper and tell it to embed
+     * class information in the serialized values because we cannot pass the expected
+     * class into the ObjectMapper.readValue method.
+     *
+     * @param objectMapper The application ObjectMapper
+     */
+    public RedisJsonSerializer(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper.copy();
+        this.objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+    }
+
+    @Override
+    public byte[] serialize(final Object obj) throws SerializationException {
+        try {
+            return objectMapper.writeValueAsBytes(obj);
+        } catch (final JsonProcessingException e) {
+            throw new SerializationException("Redis is unable to serialize object", e);
+        }
+    }
+
+    @Override
+    public Object deserialize(final byte[] bytes) throws SerializationException {
+        if (bytes == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(bytes, Object.class);
+        } catch (final IOException e) {
+            throw new SerializationException("Redis is unable to deserialize object", e);
+        }
+    }
+}

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactoryTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactoryTest.java
@@ -1,0 +1,96 @@
+package tds.dll.common.performance.caching.impl;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.redis.connection.jedis.JedisConnection;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.util.Pool;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JedisSentinelConnectionFactoryTest {
+
+    private static final String MasterName = "myMaster";
+
+    private static final Set<String> Sentinels = ImmutableSet.of(
+        "host1:5000",
+        "host2:5000",
+        "host2:5001");
+
+    @Mock
+    private Pool<Jedis> mockJedisPool;
+
+    @Mock
+    private Jedis mockJedis;
+
+    @Mock
+    private JedisConnection mockJedisConnection;
+
+    private JedisSentinelConnectionFactory connectionFactory;
+
+    @Before
+    public void setup() {
+        connectionFactory = spy(new JedisSentinelConnectionFactory(MasterName, Sentinels));
+
+        doReturn(mockJedisConnection)
+            .when(connectionFactory)
+            .createConnection(isA(Jedis.class));
+
+        doReturn(mockJedisPool)
+            .when(connectionFactory)
+            .createPool();
+
+        when(mockJedisPool.getResource()).thenReturn(mockJedis);
+    }
+
+    @Test
+    public void itShouldProvideAJedisConnection() {
+        connectionFactory.afterPropertiesSet();
+        final JedisConnection connection = connectionFactory.getConnection();
+        verify(connection).setConvertPipelineAndTxResults(connectionFactory.getConvertPipelineAndTxResults());
+        verify(connectionFactory).postProcessConnection(connection);
+        verify(mockJedisPool).getResource();
+    }
+
+    @Test
+    public void itShouldStoreAndRetrieveProperties() {
+        connectionFactory.setConvertPipelineAndTxResults(false);
+        connectionFactory.setDatabase(1);
+        connectionFactory.setPassword("password");
+        connectionFactory.setTimeout(1234);
+
+        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setBlockWhenExhausted(true);
+        connectionFactory.setPoolConfig(poolConfig);
+
+        assertThat(connectionFactory.getConvertPipelineAndTxResults()).isFalse();
+        assertThat(connectionFactory.getDatabase()).isEqualTo(1);
+        assertThat(connectionFactory.getPassword()).isEqualTo("password");
+        assertThat(connectionFactory.getTimeout()).isEqualTo(1234);
+        assertThat(connectionFactory.getPoolConfig()).isEqualTo(poolConfig);
+    }
+
+    @Test
+    public void itShouldDestroyThePoolOnShutdown() {
+        connectionFactory.destroy();
+        verifyZeroInteractions(mockJedisPool);
+
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.destroy();
+        verify(mockJedisPool).destroy();
+    }
+}

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManagerTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManagerTest.java
@@ -1,0 +1,44 @@
+package tds.dll.common.performance.caching.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.redis.core.RedisTemplate;
+import tds.dll.common.performance.caching.CacheType;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static tds.dll.common.performance.caching.CacheType.LongTerm;
+import static tds.dll.common.performance.caching.CacheType.MediumTerm;
+import static tds.dll.common.performance.caching.CacheType.ShortTerm;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NameAwareRedisCacheManagerTest {
+
+    private static final long shortTerm = 1;
+    private static final long mediumTerm = 2;
+    private static final long longTerm = 3;
+
+    @Mock
+    private RedisTemplate mockRedisTemplate;
+
+    private NameAwareRedisCacheManager cacheManager;
+
+    @Before
+    public void setup() {
+        cacheManager = new NameAwareRedisCacheManager(mockRedisTemplate, shortTerm, mediumTerm, longTerm);
+    }
+
+    @Test
+    public void itShouldConfigureExpirationTimesBasedUponName() throws Exception {
+        final Map<String, Long> expirationMap = cacheManager.asExpires(shortTerm, mediumTerm, longTerm);
+        assertThat(expirationMap).containsOnly(
+            entry(ShortTerm, shortTerm),
+            entry(MediumTerm, mediumTerm),
+            entry(LongTerm, longTerm));
+    }
+}

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/RedisJsonSerializerTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/RedisJsonSerializerTest.java
@@ -1,0 +1,38 @@
+package tds.dll.common.performance.caching.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import tds.dll.common.performance.domain.Externs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedisJsonSerializerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private RedisJsonSerializer serializer;
+
+    @Before
+    public void setup() {
+        serializer = new RedisJsonSerializer(objectMapper);
+    }
+
+    @Test
+    public void itShouldSerializeAndDeserializeAnObject() {
+        final Externs externs = new Externs();
+        externs.setClientName("client");
+        externs.setClientStylePath("path");
+        externs.setEnvironment("env");
+        externs.setIsPracticeTest(true);
+        externs.setProctorCheckin("checkin");
+
+        final byte[] serializedBytes = serializer.serialize(externs);
+        final Externs deserialized = (Externs) serializer.deserialize(serializedBytes);
+        assertThat(deserialized.getClientName()).isEqualTo(externs.getClientName());
+        assertThat(deserialized.getClientStylePath()).isEqualTo(externs.getClientStylePath());
+        assertThat(deserialized.getEnvironment()).isEqualTo(externs.getEnvironment());
+        assertThat(deserialized.getIsPracticeTest()).isEqualTo(externs.getIsPracticeTest());
+        assertThat(deserialized.getProctorCheckin()).isEqualTo(externs.getProctorCheckin());
+    }
+}


### PR DESCRIPTION
This PR adds support for caching via a Sentinel-managed Redis cluster.

Note that this PR just adds the required classes for being able to use Redis for distributed caching.  Configuration and bean registration are the responsibility of the consuming application if it wishes to use Redis caching.