### PR TITLE
TDS-1170: Bugfix/add msb column

### DIFF
--- a/tds-dll-schemas/src/main/resources/sql/MYSQL/configs/create_tables.sql
+++ b/tds-dll-schemas/src/main/resources/sql/MYSQL/configs/create_tables.sql
@@ -435,6 +435,7 @@ create table `client_testproperties`  (
 	`initialabilitytestid`      varchar(100) DEFAULT NULL,
 	`proctoreligibility`        int not null default 0,
 	`category`                  varchar(50) null,
+    `msb`                       bit not null default 0,
 	constraint `pk_client_testproperties` primary key clustered(`clientname`,`testid`)
 ) default charset = UTF8;
 


### PR DESCRIPTION
[TDS-1170](https://jira.fairwaytech.com/browse/TDS-1170):  Add the `msb` column to the part of the script that creates the `client_testproperties` table.

An alternate approach would be to introduce a new migration that performs the `ALTER TABLE` and execute it after this script is complete.  If that's an approach we'd rather take, let me know and I'll close this PR in favor of that approach.