### PR TITLE
TDS-1171: Feature/add ig acc sql

### DIFF
--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactory.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactory.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManager.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManager.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import com.google.common.collect.ImmutableList;

--- a/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/RedisJsonSerializer.java
+++ b/tds-dll-common/src/main/java/tds/dll/common/performance/caching/impl/RedisJsonSerializer.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactoryTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/JedisSentinelConnectionFactoryTest.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import com.google.common.collect.ImmutableSet;

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManagerTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/NameAwareRedisCacheManagerTest.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import org.junit.Before;

--- a/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/RedisJsonSerializerTest.java
+++ b/tds-dll-common/src/test/java/tds/dll/common/performance/caching/impl/RedisJsonSerializerTest.java
@@ -1,3 +1,16 @@
+/***************************************************************************************************
+ * Educational Online Test Delivery System
+ * Copyright (c) 2017 Regents of the University of California
+ *
+ * Distributed under the AIR Open Source License, Version 1.0
+ * See accompanying file AIR-License-1_0.txt or at
+ * http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source_Software_License.pdf
+ *
+ * SmarterApp Open Source Assessment Software Project: http://smarterapp.org
+ * Developed by Fairway Technologies, Inc. (http://fairwaytech.com)
+ * for the Smarter Balanced Assessment Consortium (http://smarterbalanced.org)
+ **************************************************************************************************/
+
 package tds.dll.common.performance.caching.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/tds-dll-schemas/src/main/resources/sql/MYSQL/configs/create_tables.sql
+++ b/tds-dll-schemas/src/main/resources/sql/MYSQL/configs/create_tables.sql
@@ -435,6 +435,7 @@ create table `client_testproperties`  (
 	`initialabilitytestid`      varchar(100) DEFAULT NULL,
 	`proctoreligibility`        int not null default 0,
 	`category`                  varchar(50) null,
+    `msb`                       bit not null default 0,
 	constraint `pk_client_testproperties` primary key clustered(`clientname`,`testid`)
 ) default charset = UTF8;
 

--- a/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
+++ b/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
@@ -1,0 +1,160 @@
+-- ---------------------------------------------------------------------------------------------------------------------
+-- Description:  Insert database records to create an Illustration Glossary for an assessment.  Records are inserted
+-- into the following tables:
+--
+--  * configs.client_testtooltype
+--  * configs.client_testtool
+--  * configs.tds_coremessageobject
+--  * configs.tds_coremessageuser
+--
+-- Records will be deleted from the following tables, which is required to ensure the updated messages are displayed on
+-- the client:
+--
+--  * configs.__appmessages
+--  * configs.__appmessagecontexts
+--
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+--
+-- This script must be updated an run for EACH assessment that needs an Illustration Glossary accommodation
+--
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+--
+-- Usage: Update the placeholder values in the script below then execute the script
+-- ---------------------------------------------------------------------------------------------------------------------
+USE configs;
+
+START TRANSACTION;
+INSERT INTO configs.client_testtooltype(
+    clientname,
+    toolname,
+    allowchange,
+    tideselectable,
+    rtsfieldname,
+    isrequired,
+    tideselectablebysubject,
+    isselectable,
+    isvisible,
+    studentcontrol,
+    tooldescription,
+    sortorder,
+    dateentered,
+    origin,
+    source,
+    contexttype,
+    context,
+    dependsontooltype,
+    disableonguestsession,
+    isfunctional,
+    testmode,
+    isentrycontrol)
+VALUES (
+    '[SBAC for production assessments, SBAC_PT for practice assessments]', -- clientname
+    'Illustration Glossary', -- toolname
+    1, -- allowchange
+    1, -- tideselectable
+    'TDSAcc-ILG', -- rtsfieldname
+    0, -- isrequired
+    0, -- tideselectablebysubject
+    1, -- isselectable
+    1, -- isvisible
+    0, -- studentcontrol
+    NULL, -- tooldescription
+    0, -- sortorder
+    NOW(), -- dateentered
+    'configs_insert_ig_accommodation.sql', -- origin
+    'configs_insert_ig_accommodation.sql', -- source
+    'TEST', -- contexttype
+    '[the value of the testid column from configs.tblsetofadminsubjects for the assessment]', -- context
+    NULL, -- dependsontooltype
+    0, -- disable on guest session
+    1, -- isfunctional
+    'ALL', -- testmode
+    0); -- isentrycontrol
+COMMIT;
+
+START TRANSACTION;
+INSERT INTO configs.client_testtool(
+    clientname,
+    type,
+    code,
+    value,
+    isdefault,
+    allowcombine,
+    valuedescription,
+    context,
+    sortorder,
+    origin,
+    source,
+    contexttype,
+    testmode,
+    equivalentclientcode)
+VALUES (
+    '[SBAC for production assessments, SBAC_PT for practice assessments]', -- clientname
+    'Illustration Glossary', -- type
+    'TDS_ILG0', -- code
+    'Do not show Illustration Glossary', -- value
+    1, -- isdefault
+    0, -- allowcombine
+    'Do not show Illustration Glossary', -- valuedescription
+    '[the value of the testid column from configs.tblsetofadminsubjects]', -- context
+    -1, -- sortorder
+    'configs_insert_ig_accommodation.sql', -- origin
+    'configs_insert_ig_accommodation.sql', -- source
+    'TEST', -- contexttype
+    'ALL', -- testmode
+    null), -- equivalentclientcode
+(
+    '[SBAC for production assessments, SBAC_PT for practice assessments]', -- clientname
+    'Illustration Glossary', -- type
+    'TDS_ILG1', -- code
+    'Show Illustration Glossary', -- value
+    0, -- isdefault
+    0, -- allowcombine
+    'Show Illustration Glossary', -- valuedescription
+    '[the value of the testid column from configs.tblsetofadminsubjects]', -- context
+    1, -- sortorder
+    'configs_insert_ig_accommodation.sql', -- origin
+    'configs_insert_ig_accommodation.sql', -- source
+    'TEST', -- contexttype
+    'ALL', -- testmode
+    null); -- equivalentclientcode
+COMMIT;
+
+START TRANSACTION;
+INSERT INTO configs.tds_coremessageobject(
+    context,
+    contexttype,
+    messageid,
+    ownerapp,
+    appkey,
+    message,
+    fromclient
+)
+SELECT
+    'testshell.aspx', -- context
+    'ClientSide', -- contexttype
+    MAX(messageid) + 1, -- messageid
+    'Student', -- ownerapp
+    'TDS.WordList.illustration', -- appkey
+    'Illustration', -- message
+    'AIR' -- fromclient
+FROM
+    configs.tds_coremessageobject;
+COMMIT;
+
+START TRANSACTION;
+INSERT INTO configs.tds_coremessageuser(
+    _fk_coremessageobject,
+    systemid)
+SELECT
+    MAX(_key),
+    'Student'
+FROM
+    configs.tds_coremessageobject;
+COMMIT;
+
+-- needed in order to reset/recalc all the messages
+START TRANSACTION;
+DELETE FROM configs.__appmessages;
+DELETE FROM configs.__appmessagecontexts;
+COMMIT;

--- a/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
+++ b/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
@@ -7,6 +7,8 @@
 --  * configs.tds_coremessageobject
 --  * configs.tds_coremessageuser
 --
+--  NOTE:  The Illustration Glossary does not have any entries in the configs.client_tooldependencies table.
+--
 -- Records will be deleted from the following tables, which is required to ensure the updated messages are displayed on
 -- the client:
 --
@@ -19,12 +21,17 @@
 --
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 --
--- Usage: Update the placeholder values in the script below then execute the script
+-- Usage: Update the placeholder values in the script below then execute the script:
+--
+-- PLACEHOLDERS
+-- ------------
+-- * [SBAC for production assessments, SBAC_PT for practice assessments]
+-- * [the value of the testid column from configs.tblsetofadminsubjects for the assessment]
 -- ---------------------------------------------------------------------------------------------------------------------
 USE configs;
 
 START TRANSACTION;
-INSERT INTO configs.client_testtooltype(
+INSERT INTO client_testtooltype(
     clientname,
     toolname,
     allowchange,
@@ -73,7 +80,7 @@ VALUES (
 COMMIT;
 
 START TRANSACTION;
-INSERT INTO configs.client_testtool(
+INSERT INTO client_testtool(
     clientname,
     type,
     code,
@@ -102,7 +109,7 @@ VALUES (
     'configs_insert_ig_accommodation.sql', -- source
     'TEST', -- contexttype
     'ALL', -- testmode
-    null), -- equivalentclientcode
+    NULL), -- equivalentclientcode
 (
     '[SBAC for production assessments, SBAC_PT for practice assessments]', -- clientname
     'Illustration Glossary', -- type
@@ -117,11 +124,11 @@ VALUES (
     'configs_insert_ig_accommodation.sql', -- source
     'TEST', -- contexttype
     'ALL', -- testmode
-    null); -- equivalentclientcode
+    NULL); -- equivalentclientcode
 COMMIT;
 
 START TRANSACTION;
-INSERT INTO configs.tds_coremessageobject(
+INSERT INTO tds_coremessageobject(
     context,
     contexttype,
     messageid,
@@ -139,22 +146,22 @@ SELECT
     'Illustration', -- message
     'AIR' -- fromclient
 FROM
-    configs.tds_coremessageobject;
+    tds_coremessageobject;
 COMMIT;
 
 START TRANSACTION;
-INSERT INTO configs.tds_coremessageuser(
+INSERT INTO tds_coremessageuser(
     _fk_coremessageobject,
     systemid)
 SELECT
     MAX(_key),
     'Student'
 FROM
-    configs.tds_coremessageobject;
+    tds_coremessageobject;
 COMMIT;
 
 -- needed in order to reset/recalc all the messages
 START TRANSACTION;
-DELETE FROM configs.__appmessages;
-DELETE FROM configs.__appmessagecontexts;
+DELETE FROM __appmessages;
+DELETE FROM __appmessagecontexts;
 COMMIT;

--- a/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
+++ b/tds-dll-schemas/src/main/resources/sql/MYSQL/utils/accommodations/configs_insert_item_glossary_accommodation.sql
@@ -133,7 +133,7 @@ INSERT INTO configs.tds_coremessageobject(
 SELECT
     'testshell.aspx', -- context
     'ClientSide', -- contexttype
-    MAX(messageid) + 1, -- messageid
+    IFNULL(MAX(messageid), 0) + 1, -- messageid
     'Student', -- ownerapp
     'TDS.WordList.illustration', -- appkey
     'Illustration', -- message


### PR DESCRIPTION
[TDS-1171](https://jira.fairwaytech.com/browse/TDS-1171):  Add SQL for creating an `Illustration Glossary` accommodation for an assessment.  This SQL also clears out the "cache" tables that store the message/UI display text.

I considered making this into a stored procedure that takes in the client and assessment id, but that's an awfully specific stored procedure.  I think the script is sufficient, especially in the short-term - in the grand scheme of things I don't expect this script to be used often.